### PR TITLE
Use helm get to determine whether we need to install Crossplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This project - commonly known as "the build submodule" -  is Crossplane's
 Makefile library. This library is used to build `crossplane/crossplane`,
 `crossplane/crossplane-runtime`, and most Crossplane providers.
 
-The build submodule is only intended to support Crossplane. There's no guarantee
-of stability. There are no releases or versions, and any commit may introduce a
-breaking change. Third parties are recommended to fork rather than taking a
-dependency.
+The build submodule is only intended to support Crossplane and its extensions.
+There's no guarantee of stability. There are no releases or versions, and any
+commit may introduce a breaking change. Third parties are recommended to fork
+rather than taking a dependency.
 
 # Quickstart
 

--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -27,10 +27,10 @@ controlplane.up: $(HELM) $(KUBECTL) $(KIND)
 	@$(HELM) repo update
 ifndef CROSSPLANE_ARGS
 	@$(INFO) setting up crossplane core without args
-	@$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) get cm universal-crossplane-config >/dev/null 2>&1 || $(HELM) install crossplane --create-namespace --namespace=$(CROSSPLANE_NAMESPACE) crossplane-stable/crossplane --version $(CROSSPLANE_VERSION)
+	@$(HELM) get notes -n $(CROSSPLANE_NAMESPACE) crossplane >/dev/null 2>&1 || $(HELM) install crossplane --create-namespace --namespace=$(CROSSPLANE_NAMESPACE) crossplane-stable/crossplane --version $(CROSSPLANE_VERSION)
 else
 	@$(INFO) setting up crossplane core with args $(CROSSPLANE_ARGS)
-	@$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) get cm universal-crossplane-config >/dev/null 2>&1 || $(HELM) install crossplane --create-namespace --namespace=$(CROSSPLANE_NAMESPACE) --set "args={${CROSSPLANE_ARGS}}" crossplane-stable/crossplane --version $(CROSSPLANE_VERSION)
+	@$(HELM) get notes -n $(CROSSPLANE_NAMESPACE) crossplane >/dev/null 2>&1 || $(HELM) install crossplane --create-namespace --namespace=$(CROSSPLANE_NAMESPACE) --set "args={${CROSSPLANE_ARGS}}" crossplane-stable/crossplane --version $(CROSSPLANE_VERSION)
 endif
 
 controlplane.down: $(KIND)


### PR DESCRIPTION
Previously we were testing for a UXP ConfigMap that Crossplane doesn't install.