### PR TITLE
Ability to override Crossplane chart repository and name

### DIFF
--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -15,6 +15,8 @@
 KIND_CLUSTER_NAME ?= local-dev
 CROSSPLANE_NAMESPACE ?= crossplane-system
 CROSSPLANE_VERSION ?=
+CROSSPLANE_CHART_REPO ?= https://charts.crossplane.io/stable
+CROSSPLANE_CHART_NAME ?= crossplane
 
 CONTROLPLANE_DUMP_DIRECTORY ?= $(OUTPUT_DIR)/controlplane-dump
 
@@ -23,14 +25,14 @@ controlplane.up: $(HELM) $(KUBECTL) $(KIND)
 	@$(KIND) get kubeconfig --name $(KIND_CLUSTER_NAME) >/dev/null 2>&1 || $(KIND) create cluster --name=$(KIND_CLUSTER_NAME)
 	@$(INFO) "setting kubectl context to kind-$(KIND_CLUSTER_NAME)"
 	@$(KUBECTL) config use-context "kind-$(KIND_CLUSTER_NAME)"
-	@$(HELM) repo add crossplane-stable https://charts.crossplane.io/stable
+	@$(HELM) repo add crossplane-build-module $(CROSSPLANE_CHART_REPO) --force-update
 	@$(HELM) repo update
 ifndef CROSSPLANE_ARGS
 	@$(INFO) setting up crossplane core without args
-	@$(HELM) get notes -n $(CROSSPLANE_NAMESPACE) crossplane >/dev/null 2>&1 || $(HELM) install crossplane --create-namespace --namespace=$(CROSSPLANE_NAMESPACE) crossplane-stable/crossplane --version $(CROSSPLANE_VERSION)
+	@$(HELM) get notes -n $(CROSSPLANE_NAMESPACE) crossplane >/dev/null 2>&1 || $(HELM) install crossplane --create-namespace --namespace=$(CROSSPLANE_NAMESPACE) crossplane-build-module/$(CROSSPLANE_CHART_NAME) --version $(CROSSPLANE_VERSION)
 else
 	@$(INFO) setting up crossplane core with args $(CROSSPLANE_ARGS)
-	@$(HELM) get notes -n $(CROSSPLANE_NAMESPACE) crossplane >/dev/null 2>&1 || $(HELM) install crossplane --create-namespace --namespace=$(CROSSPLANE_NAMESPACE) --set "args={${CROSSPLANE_ARGS}}" crossplane-stable/crossplane --version $(CROSSPLANE_VERSION)
+	@$(HELM) get notes -n $(CROSSPLANE_NAMESPACE) crossplane >/dev/null 2>&1 || $(HELM) install crossplane --create-namespace --namespace=$(CROSSPLANE_NAMESPACE) --set "args={${CROSSPLANE_ARGS}}" crossplane-build-module/$(CROSSPLANE_CHART_NAME) --version $(CROSSPLANE_VERSION)
 endif
 
 controlplane.down: $(KIND)


### PR DESCRIPTION
* Ability to install crossplane from a custom helm chart repo
* Ability to override chart name
* Keep standard defaults with no breaking changes
* Required for universal-crossplane installation and mirrored chart repositories in non-standard public locations

Tested with example usage from consuming `Makefile`: https://github.com/upbound/configuration-aws-network/pull/63/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R30-R32