### PR TITLE
Add missing vendor targets

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -198,3 +198,8 @@ $(GOLANGCILINT):
 	@mv $(TOOLS_HOST_DIR)/tmp-golangci-lint/golangci-lint $(GOLANGCILINT) || $(FAIL)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp-golangci-lint
 	@$(OK) installing golangci-lint-v$(GOLANGCILINT_VERSION) $(SAFEHOSTPLATFORM)
+
+# These targets are deprecated but are still used by some existing repos.
+# The modules targets should be used instead.
+vendor: modules.download
+vendor.check: modules.check


### PR DESCRIPTION
The Crossplane build module is missing the vendor targets that were defined by the upbound build module.