### PR TITLE
Fix path for chainsaw download

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -174,7 +174,7 @@ $(KUTTL):
 $(CHAINSAW):
 	@$(INFO) installing chainsaw $(CHAINSAW_VERSION)
 	@mkdir -p $(TOOLS_HOST_DIR)
-	@curl -fsSLo $(CHAINSAW).tar.gz --create-dirs https://github.com/kyverno/chainsaw/releases/download/v$(CHAINSAW_VERSION)/chainsaw_$(HOST_PLATFORM).tar.gz || $(FAIL)
+	@curl -fsSLo $(CHAINSAW).tar.gz --create-dirs https://github.com/kyverno/chainsaw/releases/download/v$(CHAINSAW_VERSION)/chainsaw_$(SAFEHOST_PLATFORM).tar.gz || $(FAIL)
 	@tar -xvf $(CHAINSAW).tar.gz chainsaw
 	@mv chainsaw $(CHAINSAW)
 	@chmod +x $(CHAINSAW)


### PR DESCRIPTION
This PR changes the download path for Chainsaw.

Chainsaw download path should use `SAFEHOST_PLATFORM` naming convention (eg `linux_amd64`):
https://github.com/kyverno/chainsaw/releases/download/v0.2.0/chainsaw_linux_amd64.tar.gz

not `HOST_PLATFORM` naming convention (eg `linux_x86_64`):
https://github.com/kyverno/chainsaw/releases/download/v0.2.0/chainsaw_linux_x86_64.tar.gz