### PR TITLE
Bump kind to 0.23.0 to fetch kindest/node:v1.30.0 instead of v1.25.2

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -25,7 +25,7 @@ ISTIO_DOWNLOAD_TUPLE := osx-$(SAFEHOSTARCH)
 endif
 
 # the version of kind to use
-KIND_VERSION ?= v0.16.0
+KIND_VERSION ?= v0.23.0
 KIND := $(TOOLS_HOST_DIR)/kind-$(KIND_VERSION)
 
 # the version of kubectl to use


### PR DESCRIPTION
Bumping `kind` version to `v0.23.0` to fetch a fresher `kindest/node:` image. The current version fetches `1.25.2` and the latest is `1.30.0`.