### PR TITLE
Move release branch filter to the variable

### DIFF
--- a/makelib/imagelight.mk
+++ b/makelib/imagelight.mk
@@ -124,9 +124,9 @@ endif
 build.done: img.done
 clean: img.clean img.release.clean
 
-# only publish images for main / master and release branches
-# TODO(hasheddan): remove master and support overriding
-ifneq ($(filter main master release-%,$(BRANCH_NAME)),)
+# only publish images for main / master and release branches by default
+RELEASE_BRANCH_FILTER ?= main master release-%
+ifneq ($(filter $(RELEASE_BRANCH_FILTER),$(BRANCH_NAME)),)
 publish.artifacts: $(foreach r,$(REGISTRY_ORGS), $(foreach i,$(IMAGES),img.release.publish.$(r).$(i)))
 endif
 

--- a/makelib/xpkg.mk
+++ b/makelib/xpkg.mk
@@ -121,9 +121,9 @@ else
 build.artifacts.platform: do.skip.xpkgs
 endif
 
-# only publish package for main / master and release branches
-# TODO(hasheddan): remove master and support overriding
-ifneq ($(filter main master release-%,$(BRANCH_NAME)),)
+# only publish package for main / master and release branches by default
+RELEASE_BRANCH_FILTER ?= main master release-%
+ifneq ($(filter $(RELEASE_BRANCH_FILTER),$(BRANCH_NAME)),)
 publish.artifacts: $(foreach r,$(XPKG_REG_ORGS), $(foreach x,$(XPKGS),xpkg.release.publish.$(r).$(x)))
 endif
 


### PR DESCRIPTION

### Description of your changes

Before this change, the xpkg publishing was limited from the branches limited to the hardcoded filter of
```
main master release-%
```

After this change, we keep the same backward compatible defaults providing the ability to override the release branch filter

```
make -j2 publish RELEASE_BRANCH_FILTER="feature/%" BRANCH_NAME=feature/test XPKG_REG_ORGS=xpkg.upbound/test/me
```

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

* Matching branch filter pushing the packages
```
make -j2 publish RELEASE_BRANCH_FILTER="feature/%" BRANCH_NAME=feature/test XPKG_REG_ORGS=xpkg.upbound/test/me
```

* Default filter still works 
```
make -j2 publish BRANCH_NAME=main XPKG_REG_ORGS=XPKG_REG_ORGS=xpkg.upbound/test/me #pushes the package
make -j2 publish BRANCH_NAME=release-test XPKG_REG_ORGS=xpkg.upbound/test/me #pushes the package
make -j2 publish BRANCH_NAME=test XPKG_REG_ORGS=xpkg.upbound/test/me #skips pushing
```
