### PR TITLE
Cleanup xpkg examples only if enabled

### DIFF
--- a/makelib/xpkg.mk
+++ b/makelib/xpkg.mk
@@ -60,7 +60,13 @@ XPKG_ARCHS := $(subst linux_,,$(filter linux_%,$(PLATFORMS)))
 XPKG_PLATFORMS := $(subst _,/,$(subst $(SPACE),$(COMMA),$(filter linux_%,$(PLATFORMS))))
 XPKG_PLATFORMS_LIST := $(subst _,/,$(filter linux_%,$(PLATFORMS)))
 XPKG_PLATFORM := $(subst _,/,$(PLATFORM))
+
+XPKG_CLEANUP_EXAMPLES_ENABLED ?= false
 XPKG_CLEANUP_EXAMPLES_VERSION ?= v0.12.1
+XPKG_PROCESSED_EXAMPLES_DIR=$(XPKG_EXAMPLES_DIR)
+ifeq ($(XPKG_CLEANUP_EXAMPLES_ENABLED),true)
+	XPKG_PROCESSED_EXAMPLES_DIR=$(WORK_DIR)/xpkg-cleaned-examples
+endif
 
 # TODO(negz): Update these targets to use the crossplane CLI, not up.
 UP ?= up
@@ -71,8 +77,10 @@ UP ?= up
 # 1: xpkg
 define xpkg.build.targets
 xpkg.build.$(1):
+ifeq ($(XPKG_CLEANUP_EXAMPLES_ENABLED),true)
 	@rm -rf $(WORK_DIR)/xpkg-cleaned-examples
-	@GOOS=$(HOSTOS) GOARCH=$(TARGETARCH) go run github.com/upbound/uptest/cmd/cleanupexamples@$(XPKG_CLEANUP_EXAMPLES_VERSION) $(XPKG_EXAMPLES_DIR) $(WORK_DIR)/xpkg-cleaned-examples || $(FAIL)
+	@GOOS=$(HOSTOS) GOARCH=$(TARGETARCH) go run github.com/upbound/uptest/cmd/cleanupexamples@$(XPKG_CLEANUP_EXAMPLES_VERSION) $(XPKG_EXAMPLES_DIR) $(XPKG_PROCESSED_EXAMPLES_DIR) || $(FAIL)
+endif
 	@$(INFO) Building package $(1)-$(VERSION).xpkg for $(PLATFORM)
 	@mkdir -p $(OUTPUT_DIR)/xpkg/$(PLATFORM)
 	@controller_arg=$$$$(grep -E '^kind:\s+Provider\s*$$$$' $(XPKG_DIR)/crossplane.yaml > /dev/null && echo "--controller $(BUILD_REGISTRY)/$(1)-$(ARCH)"); \
@@ -80,11 +88,13 @@ xpkg.build.$(1):
 		$$$${controller_arg} \
 		--package-root $(XPKG_DIR) \
 		--auth-ext $(XPKG_AUTH_EXT) \
-		--examples-root $(WORK_DIR)/xpkg-cleaned-examples \
+		--examples-root $(XPKG_PROCESSED_EXAMPLES_DIR) \
 		--ignore $(XPKG_IGNORE) \
 		--output $(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(1)-$(VERSION).xpkg || $(FAIL)
 	@$(OK) Built package $(1)-$(VERSION).xpkg for $(PLATFORM)
+ifeq ($(XPKG_CLEANUP_EXAMPLES_ENABLED),true)
 	@rm -rf $(WORK_DIR)/xpkg-cleaned-examples
+endif
 xpkg.build: xpkg.build.$(1)
 endef
 $(foreach x,$(XPKGS),$(eval $(call xpkg.build.targets,$(x))))


### PR DESCRIPTION
This PR introduces a new variable, `XPKG_CLEANUP_EXAMPLES_ENABLED` and runs the example cleanup step only if this variable set to `true` by the caller.