### PR TITLE
Update golangci-lint to 1.61.0

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -77,7 +77,7 @@ GO_VERSION := $(shell $(GO) version | sed -ne 's/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION ?= 1.54.0
+GOLANGCILINT_VERSION ?= 1.61.0
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)


### PR DESCRIPTION
This resolves a problem on macOS (arm64) where lint fails with error message from typecheck.

Example:

```
14:02:02 [ .. ] golangci-lint
apis/accesscontextmanager/v1beta1/zz_accesslevel_terraformed.go:87:79: tr.GetName undefined (type *AccessLevel has no field or method GetName) (typecheck)
                return nil, errors.Wrapf(err, "cannot get parameters for resource '%q'", tr.GetName())
                                                                                            ^
```

For more information see https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors