### PR TITLE
Fix UPTEST_RENDER_ONLY

### DIFF
--- a/makelib/uptest.mk
+++ b/makelib/uptest.mk
@@ -31,7 +31,7 @@ ifdef UPTEST_DEFAULT_TIMEOUT
 endif
 
 UPTEST_RENDER_ONLY ?= false
-ifeq ($(UPTEST_SKIP_DELETE),true)
+ifeq ($(UPTEST_RENDER_ONLY),true)
     UPTEST_ARGS += --render-only
 endif
 


### PR DESCRIPTION
Follow up and fix to #24 

```
make e2e UPTEST_RENDER_ONLY=true
...
2024/11/01 22:30:25 Skipping update step because the root resource does not exist
2024/11/01 22:30:25 Skipping update step because the skip-delete option is set to true
2024/11/01 22:30:25 Written test files: /var/folders/sx/0tlfb9ys20bbqnszv3lw12m40000gn/T/uptest-e2e
22:30:25 [ OK ] running automated tests
```

```
make e2e UPTEST_SKIP_DELETE=true
...
2024/11/01 22:14:02     | 22:14:02 | import | Assert Status Conditions and IDs | TRY       | DONE  |
2024/11/01 22:14:02 --- PASS: chainsaw (0.00s)
2024/11/01 22:14:02     --- PASS: chainsaw/import (25.20s)
2024/11/01 22:14:02 PASS
2024/11/01 22:14:02 Tests Summary...
2024/11/01 22:14:02 - Passed  tests 1
2024/11/01 22:14:02 - Failed  tests 0
2024/11/01 22:14:02 - Skipped tests 0
2024/11/01 22:14:02 Done.
2024/11/01 22:14:02 Skipping test 03-delete.yaml
22:14:02 [ OK ] running automated tests
```

The test in #24 was 'successful' because of the polluted shell environment.