### PR TITLE
Use official kubectl download url

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -135,7 +135,7 @@ $(KIND):
 # kubectl download and install
 $(KUBECTL):
 	@$(INFO) installing kubectl $(KUBECTL_VERSION)
-	@curl -fsSLo $(KUBECTL) --create-dirs https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/$(HOSTOS)/$(SAFEHOSTARCH)/kubectl || $(FAIL)
+	@curl -fsSLo $(KUBECTL) --create-dirs https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(HOSTOS)/$(SAFEHOSTARCH)/kubectl || $(FAIL)
 	@chmod +x $(KUBECTL)
 	@$(OK) installing kubectl $(KUBECTL_VERSION)
 


### PR DESCRIPTION
The old url seems not to work anymore. Replaced it with the official url: https://kubernetes.io/releases/download/

```
curl -v https://storage.googleapis.com/kubernetes-release/release/v1.32.2/bin/linux/amd64/kubectl
< HTTP/2 404
```


```
curl -v https://dl.k8s.io/kubernetes-release/release/v1.32.2/bin/linux/amd64/kubectl
< HTTP/2 302
```