### PR TITLE
feat(cli): remove up-cli, olm, update copyrights and switch to crossplane cli

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 The Upbound Authors. All rights reserved.
+   Copyright 2025 The Crossplane Authors. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -1,4 +1,4 @@
-# Copyright 2016 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -1,4 +1,4 @@
-# Copyright 2022 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -1,4 +1,4 @@
-# Copyright 2016 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -1,4 +1,4 @@
-# Copyright 2016 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/makelib/imagelight.mk
+++ b/makelib/imagelight.mk
@@ -1,4 +1,4 @@
-# Copyright 2021 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -1,4 +1,4 @@
-# Copyright 2016 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,17 +40,8 @@ KUBECTL := $(TOOLS_HOST_DIR)/kubectl-$(KUBECTL_VERSION)
 KUSTOMIZE_VERSION ?= v4.5.5
 KUSTOMIZE := $(TOOLS_HOST_DIR)/kustomize-$(KUSTOMIZE_VERSION)
 
-# the version of olm-bundle to use
-OLMBUNDLE_VERSION ?= v0.5.2
-OLMBUNDLE := $(TOOLS_HOST_DIR)/olm-bundle-$(OLMBUNDLE_VERSION)
-
-# the version of up to use
-UP_VERSION ?= v0.28.0
-UP_CHANNEL ?= stable
-UP := $(TOOLS_HOST_DIR)/up-$(UP_VERSION)
-
 # the version of crossplane cli to use
-CROSSPLANE_CLI_VERSION ?= v1.14.5
+CROSSPLANE_CLI_VERSION ?= v1.20.0
 CROSSPLANE_CLI_CHANNEL ?= stable
 CROSSPLANE_CLI := $(TOOLS_HOST_DIR)/crossplane-cli-$(CROSSPLANE_CLI_VERSION)
 
@@ -88,12 +79,12 @@ YQ := $(TOOLS_HOST_DIR)/yq-$(YQ_VERSION)
 # Common Targets
 
 k8s_tools.buildvars:
+	@echo CROSSPLANE_CLI=$(CROSSPLANE_CLI)
 	@echo KCL=$(KCL)
 	@echo KIND=$(KIND)
 	@echo KUBECTL=$(KUBECTL)
 	@echo KUSTOMIZE=$(KUSTOMIZE)
 	@echo OLM_BUNDLE=$(OLM_BUNDLE)
-	@echo UP=$(UP)
 	@echo HELM=$(HELM)
 	@echo KUTTL=$(KUTTL)
 	@echo CHAINSAW=$(CHAINSAW)
@@ -147,20 +138,6 @@ $(KUSTOMIZE):
 	@mv $(TOOLS_HOST_DIR)/tmp-kustomize/kustomize $(KUSTOMIZE)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp-kustomize
 	@$(OK) installing kustomize $(KUSTOMIZE_VERSION)
-
-# olm-bundle download and install
-$(OLMBUNDLE):
-	@$(INFO) installing olm-bundle $(OLMBUNDLE_VERSION)
-	@curl -fsSLo $(OLMBUNDLE) https://github.com/upbound/olm-bundle/releases/download/$(OLMBUNDLE_VERSION)/olm-bundle_$(SAFEHOSTPLATFORM) || $(FAIL)
-	@chmod +x $(OLMBUNDLE)
-	@$(OK) installing olm-bundle $(OLMBUNDLE_VERSION)
-
-# up download and install
-$(UP):
-	@$(INFO) installing up $(UP_VERSION)
-	@curl -fsSLo $(UP) --create-dirs https://cli.upbound.io/$(UP_CHANNEL)/$(UP_VERSION)/bin/$(SAFEHOST_PLATFORM)/up?source=build || $(FAIL)
-	@chmod +x $(UP)
-	@$(OK) installing up $(UP_VERSION)
 
 # Crossplane CLI download and install
 $(CROSSPLANE_CLI):

--- a/makelib/local.xpkg.mk
+++ b/makelib/local.xpkg.mk
@@ -1,4 +1,4 @@
-# Copyright 2022 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,13 +25,10 @@ local.xpkg.init: $(KUBECTL)
 	fi
 	@$(OK) patching Crossplane with dev sidecar
 
-# TODO(negz): Update this target to use the crossplane CLI, not up. We'll need
-# to add the `xpkg extract` subcommand to the crossplane CLI.
-
-local.xpkg.sync: local.xpkg.init $(UP)
+local.xpkg.sync: local.xpkg.init $(CROSSPLANE_CLI)
 	@$(INFO) copying local xpkg cache to Crossplane pod
 	@mkdir -p $(XPKG_OUTPUT_DIR)/cache
-	@for pkg in $(XPKG_OUTPUT_DIR)/linux_*/*; do $(UP) xpkg xp-extract --from-xpkg $$pkg -o $(XPKG_OUTPUT_DIR)/cache/$$(basename $$pkg .xpkg).gz; done
+	@for pkg in $(XPKG_OUTPUT_DIR)/linux_*/*; do $(CROSSPLANE_CLI) xpkg extract --from-xpkg $$pkg -o $(XPKG_OUTPUT_DIR)/cache/$$(basename $$pkg .xpkg).gz; done
 	@XPPOD=$$($(KUBECTL) -n $(CROSSPLANE_NAMESPACE) get pod -l app=crossplane,patched=true -o jsonpath="{.items[0].metadata.name}"); \
 		$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) cp $(XPKG_OUTPUT_DIR)/cache -c dev $$XPPOD:/tmp
 	@$(OK) copying local xpkg cache to Crossplane pod

--- a/makelib/output.mk
+++ b/makelib/output.mk
@@ -1,4 +1,4 @@
-# Copyright 2016 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/makelib/uptest.mk
+++ b/makelib/uptest.mk
@@ -1,3 +1,17 @@
+# Copyright 2025 The Crossplane Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # ====================================================================================
 # End to End Testing
 

--- a/makelib/xpkg.mk
+++ b/makelib/xpkg.mk
@@ -1,4 +1,4 @@
-# Copyright 2022 The Upbound Authors. All rights reserved.
+# Copyright 2025 The Crossplane Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,8 +53,8 @@ ifeq ($(origin BUILD_REGISTRY), undefined)
 BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | $(SHA256SUM) | cut -c1-8)
 endif
 
-XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane
-XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane
+XPKG_REG_ORGS ?= xpkg.crossplane.io/crossplane
+XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.crossplane.io/crossplane
 XPKG_LINUX_PLATFORMS := $(filter linux_%,$(PLATFORMS))
 XPKG_ARCHS := $(subst linux_,,$(filter linux_%,$(PLATFORMS)))
 XPKG_PLATFORMS := $(subst _,/,$(subst $(SPACE),$(COMMA),$(filter linux_%,$(PLATFORMS))))
@@ -67,9 +67,6 @@ XPKG_PROCESSED_EXAMPLES_DIR=$(XPKG_EXAMPLES_DIR)
 ifeq ($(XPKG_CLEANUP_EXAMPLES_ENABLED),true)
 	XPKG_PROCESSED_EXAMPLES_DIR=$(WORK_DIR)/xpkg-cleaned-examples
 endif
-
-# TODO(negz): Update these targets to use the crossplane CLI, not up.
-UP ?= up
 
 # =====================================================================================
 # XPKG Targets
@@ -84,7 +81,7 @@ endif
 	@$(INFO) Building package $(1)-$(VERSION).xpkg for $(PLATFORM)
 	@mkdir -p $(OUTPUT_DIR)/xpkg/$(PLATFORM)
 	@controller_arg=$$$$(grep -E '^kind:\s+Provider\s*$$$$' $(XPKG_DIR)/crossplane.yaml > /dev/null && echo "--controller $(BUILD_REGISTRY)/$(1)-$(ARCH)"); \
-	$(UP) xpkg build \
+	$(CROSSPLANE_CLI) xpkg build \
 		$$$${controller_arg} \
 		--package-root $(XPKG_DIR) \
 		--auth-ext $(XPKG_AUTH_EXT) \
@@ -103,7 +100,7 @@ $(foreach x,$(XPKGS),$(eval $(call xpkg.build.targets,$(x))))
 define xpkg.release.targets
 xpkg.release.publish.$(1).$(2):
 	@$(INFO) Pushing package $(1)/$(2):$(VERSION)
-	@$(UP) xpkg push \
+	@$(CROSSPLANE_CLI) xpkg push \
 		$(foreach p,$(XPKG_LINUX_PLATFORMS),--package $(XPKG_OUTPUT_DIR)/$(p)/$(2)-$(VERSION).xpkg ) \
 		$(1)/$(2):$(VERSION) || $(FAIL)
 	@$(OK) Pushed package $(1)/$(2):$(VERSION)


### PR DESCRIPTION
after https://github.com/crossplane/crossplane/pull/6262 
we can release a new build module version

- switch up-cli commands to crossplane-cli commands
- bump crossplane-cli default version from v1.14.5 to v1.20.0 
- remove old unused olmbundle 
- update copyright from upbound to crossplane
- switch xpkg.upbound.io to xpkg.crossplane.io

Fixes https://github.com/crossplane/build/issues/3