### PR TITLE
add MULTI_ARCH_BUILD to omit arch from image name

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -140,16 +140,22 @@ ifeq ($(origin PLATFORM),undefined)
 PLATFORM := $(TARGET_PLATFORM)
 # if the target platform is on the supported list add it to the single build target
 ifneq ($(filter $(PLATFORMS),$(TARGET_PLATFORM)),)
+ifndef MULTI_ARCH_BUILD
 BUILD_PLATFORMS = $(TARGET_PLATFORM)
+endif
 endif
 
 # for convenience always build the linux platform when building on mac
 ifneq ($(HOSTOS),linux)
+ifndef MULTI_ARCH_BUILD
 BUILD_PLATFORMS += linux_$(TARGETARCH)
+endif
 endif
 
 else
+ifndef MULTI_ARCH_BUILD
 BUILD_PLATFORMS = $(PLATFORM)
+endif
 endif
 
 OS := $(word 1, $(subst _, ,$(PLATFORM)))


### PR DESCRIPTION
To support [multi-arch builds](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) practice is to omit arch from the image name. OCI registry will handle everything else.

How does this gonna work:
cluster/images/<foo>/Makefile use mutli-arch builds (see `@docker buildx create --use --name multiarch-builder || true`) 

Set multi-arch build flag:
```
PLATFORMS ?= linux_amd64 linux_arm64
MULTI_ARCH_BUILD ?= true
```

And build:
```
img.build.shared:
	@mkdir -p $(IMAGE_TEMP_DIR)
	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
	@cp -r $(OUTPUT_DIR)/bin/ $(IMAGE_TEMP_DIR)/bin || $(FAIL)
	@cp -r $(ROOT_DIR)/cmd/api-potato/cmd/manifest $(IMAGE_TEMP_DIR)/manifest || $(FAIL)
	@docker buildx create --use --name multiarch-builder || true
	@docker buildx build $(BUILD_ARGS) \
		--platform $(IMAGE_PLATFORMS) \
		--tag $(IMAGE) \
		--file $(IMAGE_TEMP_DIR)/Dockerfile \
		--progress=plain \
		$(IMAGE_TEMP_DIR) || $(FAIL)
	@rm -rf $(IMAGE_TEMP_DIR)
```

Implemented will need to handle publishing as its need to be part of build step now. Locally this will build only image which is set to current host arch. 

More changes might come later for publishing stage, but this allows to start building. 