### PR TITLE
Fix: use VERSION as tag to build docker image

### DIFF
--- a/makelib/imagelight.mk
+++ b/makelib/imagelight.mk
@@ -111,7 +111,7 @@ $(foreach r,$(REGISTRY_ORGS), $(foreach i,$(IMAGES),$(eval $(call repo.targets,$
 # Common Targets
 
 do.build.image.%:
-	@$(MAKE) -C $(IMAGE_DIR)/$* IMAGE_PLATFORMS=$(IMAGE_PLATFORM) IMAGE=$(BUILD_REGISTRY)/$*-$(ARCH) img.build
+	@$(MAKE) -C $(IMAGE_DIR)/$* IMAGE_PLATFORMS=$(IMAGE_PLATFORM) IMAGE=$(BUILD_REGISTRY)/$*:$(VERSION) img.build
 do.build.images: $(foreach i,$(IMAGES), do.build.image.$(i))
 do.skip.images:
 	@$(OK) Skipping image build for unsupported platform $(IMAGE_PLATFORM)


### PR DESCRIPTION
**Issue:** Currently, build images are tagged using the architecture (ARCH). However, during the image publishing process, the version (VERSION) is used as the tag. This leads to errors and prevents successful image pushes.

Here is img.publish use VERSION as a tag to push the image 
https://github.com/crossplane/build/blob/3cca5e897eb8d66dfa22c9f44724b78e62926439/makelib/imagelight.mk#L94


**Fix:** To fix this, use VERSION as a tag when building the image.