### PR TITLE
update crossplane cli usage to correct flags

### DIFF
--- a/makelib/xpkg.mk
+++ b/makelib/xpkg.mk
@@ -19,13 +19,6 @@ ifeq ($(origin XPKG_DIR),undefined)
 XPKG_DIR := $(ROOT_DIR)/package
 endif
 
-# xref https://github.com/upbound/provider-aws/pull/647, https://github.com/upbound/up/pull/309
-# in up v0.16.0, support for ProviderConfig documentation via object annotations was added.
-# by convention, we will assume the extensions file resides in the package directory.
-ifeq ($(origin XPKG_AUTH_EXT),undefined)
-XPKG_AUTH_EXT := $(XPKG_DIR)/auth.yaml
-endif
-
 ifeq ($(origin XPKG_EXAMPLES_DIR),undefined)
 XPKG_EXAMPLES_DIR := $(ROOT_DIR)/examples
 endif
@@ -80,14 +73,13 @@ ifeq ($(XPKG_CLEANUP_EXAMPLES_ENABLED),true)
 endif
 	@$(INFO) Building package $(1)-$(VERSION).xpkg for $(PLATFORM)
 	@mkdir -p $(OUTPUT_DIR)/xpkg/$(PLATFORM)
-	@controller_arg=$$$$(grep -E '^kind:\s+Provider\s*$$$$' $(XPKG_DIR)/crossplane.yaml > /dev/null && echo "--controller $(BUILD_REGISTRY)/$(1)-$(ARCH)"); \
+	@controller_arg=$$$$(grep -E '^kind:\s+Provider\s*$$$$' $(XPKG_DIR)/crossplane.yaml > /dev/null && echo "--embed-runtime-image $(BUILD_REGISTRY)/$(1)-$(ARCH)"); \
 	$(CROSSPLANE_CLI) xpkg build \
 		$$$${controller_arg} \
 		--package-root $(XPKG_DIR) \
-		--auth-ext $(XPKG_AUTH_EXT) \
 		--examples-root $(XPKG_PROCESSED_EXAMPLES_DIR) \
 		--ignore $(XPKG_IGNORE) \
-		--output $(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(1)-$(VERSION).xpkg || $(FAIL)
+		--package-file $(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(1)-$(VERSION).xpkg || $(FAIL)
 	@$(OK) Built package $(1)-$(VERSION).xpkg for $(PLATFORM)
 ifeq ($(XPKG_CLEANUP_EXAMPLES_ENABLED),true)
 	@rm -rf $(WORK_DIR)/xpkg-cleaned-examples
@@ -101,7 +93,7 @@ define xpkg.release.targets
 xpkg.release.publish.$(1).$(2):
 	@$(INFO) Pushing package $(1)/$(2):$(VERSION)
 	@$(CROSSPLANE_CLI) xpkg push \
-		$(foreach p,$(XPKG_LINUX_PLATFORMS),--package $(XPKG_OUTPUT_DIR)/$(p)/$(2)-$(VERSION).xpkg ) \
+		$(foreach p,$(XPKG_LINUX_PLATFORMS),--package-files $(XPKG_OUTPUT_DIR)/$(p)/$(2)-$(VERSION).xpkg ) \
 		$(1)/$(2):$(VERSION) || $(FAIL)
 	@$(OK) Pushed package $(1)/$(2):$(VERSION)
 xpkg.release.publish: xpkg.release.publish.$(1).$(2)


### PR DESCRIPTION
fixes: https://github.com/crossplane/build/issues/33

it seems to work in nop-provider: 

```
(╯°□°)╯︵  make build
12:58:51 [ .. ] go build linux_arm64
12:58:51 [ OK ] go build linux_arm64
12:58:52 [ .. ] docker build build-66406884/provider-nop-arm64
[+] Building 0.5s (7/7) FINISHED                                                                                                                                                                                                                                                              docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 315B                                                                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for gcr.io/distroless/static@sha256:1f580b0a1922c3e54ae15b0758b5747b260bd99d39d40c2edb3e7f6e2452298b                                                                                                                                                                             0.2s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                             0.3s
 => => transferring context: 43.59MB                                                                                                                                                                                                                                                                          0.3s
 => [1/2] FROM gcr.io/distroless/static@sha256:1f580b0a1922c3e54ae15b0758b5747b260bd99d39d40c2edb3e7f6e2452298b                                                                                                                                                                                               0.0s
 => CACHED [2/2] ADD bin/linux_arm64/provider /usr/local/bin/provider-nop                                                                                                                                                                                                                                     0.0s
 => exporting to image                                                                                                                                                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                       0.0s
 => => writing image sha256:9d1d79bc5f6e9f100a7262a522227495c9699e71dc1659521443f8a5ef08d5b1                                                                                                                                                                                                                  0.0s
 => => naming to docker.io/build-66406884/provider-nop-arm64                                                                                                                                                                                                                                                  0.0s
12:58:53 [ OK ] docker build build-66406884/provider-nop-arm64
12:58:53 [ .. ] Building package provider-nop-v0.4.0-10.g8e3a3ea.dirty.xpkg for linux_arm64
12:58:54 [ OK ] Built package provider-nop-v0.4.0-10.g8e3a3ea.dirty.xpkg for linux_arm64
```