### PR TITLE
always require crossplane-cli

### DIFF
--- a/makelib/xpkg.mk
+++ b/makelib/xpkg.mk
@@ -66,7 +66,7 @@ endif
 
 # 1: xpkg
 define xpkg.build.targets
-xpkg.build.$(1):
+xpkg.build.$(1): $(CROSSPLANE_CLI)
 ifeq ($(XPKG_CLEANUP_EXAMPLES_ENABLED),true)
 	@rm -rf $(WORK_DIR)/xpkg-cleaned-examples
 	@GOOS=$(HOSTOS) GOARCH=$(TARGETARCH) go run github.com/upbound/uptest/cmd/cleanupexamples@$(XPKG_CLEANUP_EXAMPLES_VERSION) $(XPKG_EXAMPLES_DIR) $(XPKG_PROCESSED_EXAMPLES_DIR) || $(FAIL)


### PR DESCRIPTION
prevents needing to manually depend on $CROSSPLANE_CLI in build.init