### PR TITLE
chore: bump up tools and split crossplane-cli from crossplane-bin

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -155,6 +155,7 @@ $(CROSSPLANE_BIN):
 $(CROSSPLANE_CLI):
 	@$(INFO) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
 	@curl -fsSLo $(CROSSPLANE_CLI) --create-dirs https://cli.crossplane.io/$(CROSSPLANE_CLI_CHANNEL)/$(CROSSPLANE_CLI_VERSION)/bin/$(SAFEHOST_PLATFORM)/crossplane?source=build || $(FAIL)
+	@chmod +x $(CROSSPLANE_CLI)
 	@$(OK) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
 
 # helm download and install

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -16,7 +16,7 @@
 # Options
 
 # the version of istio to use
-ISTIO_VERSION ?= 1.12.9
+ISTIO_VERSION ?= 1.30.2
 ISTIO := $(TOOLS_HOST_DIR)/istioctl-$(ISTIO_VERSION)
 ISTIOOS := $(HOSTOS)
 ISTIO_DOWNLOAD_TUPLE := $(SAFEHOSTPLATFORM)
@@ -25,29 +25,34 @@ ISTIO_DOWNLOAD_TUPLE := osx-$(SAFEHOSTARCH)
 endif
 
 # the version of kcl to use
-KCL_VERSION ?= v0.10.0
+KCL_VERSION ?= v0.11.2
 KCL := $(TOOLS_HOST_DIR)/kcl-$(KCL_VERSION)
 
 # the version of kind to use
-KIND_VERSION ?= v0.30.0
+KIND_VERSION ?= v0.32.0
 KIND := $(TOOLS_HOST_DIR)/kind-$(KIND_VERSION)
 
 # the version of kubectl to use
-KUBECTL_VERSION ?= v1.33.5
+KUBECTL_VERSION ?= v1.35.6
 KUBECTL := $(TOOLS_HOST_DIR)/kubectl-$(KUBECTL_VERSION)
 
 # the version of kustomize to use
-KUSTOMIZE_VERSION ?= v5.7.1
+KUSTOMIZE_VERSION ?= v5.8.1
 KUSTOMIZE := $(TOOLS_HOST_DIR)/kustomize-$(KUSTOMIZE_VERSION)
 
+# the version of crossplane bin to use
+CROSSPLANE_BIN_VERSION ?= v2.3.3
+CROSSPLANE_BIN_CHANNEL ?= stable
+CROSSPLANE_BIN := $(TOOLS_HOST_DIR)/crossplane-bin-$(CROSSPLANE_BIN_VERSION)
+
 # the version of crossplane cli to use
-CROSSPLANE_CLI_VERSION ?= v2.0.2
+CROSSPLANE_CLI_VERSION ?= v2.4.0
 CROSSPLANE_CLI_CHANNEL ?= stable
 CROSSPLANE_CLI := $(TOOLS_HOST_DIR)/crossplane-cli-$(CROSSPLANE_CLI_VERSION)
 
 # the version of helm 3 to use
 USE_HELM ?= false
-HELM_VERSION ?= v3.18.6
+HELM_VERSION ?= v3.21.2
 HELM := $(TOOLS_HOST_DIR)/helm-$(HELM_VERSION)
 
 # If we enable HELM we alias HELM to be HELM
@@ -60,11 +65,11 @@ HELM := $(TOOLS_HOST_DIR)/helm-$(HELM_VERSION)
 endif
 
 # the version of kuttl to use
-KUTTL_VERSION ?= 0.12.1
+KUTTL_VERSION ?= 0.26.0
 KUTTL := $(TOOLS_HOST_DIR)/kuttl-$(KUTTL_VERSION)
 
 # the version of chainsaw to use
-CHAINSAW_VERSION ?= 0.2.13
+CHAINSAW_VERSION ?= 0.2.15
 CHAINSAW := $(TOOLS_HOST_DIR)/chainsaw-$(CHAINSAW_VERSION)
 
 # the version of uptest to use
@@ -72,7 +77,7 @@ UPTEST_VERSION ?= v2.2.0
 UPTEST := $(TOOLS_HOST_DIR)/uptest-$(UPTEST_VERSION)
 
 # the version of yq to use
-YQ_VERSION ?= v4.40.5
+YQ_VERSION ?= v4.53.3
 YQ := $(TOOLS_HOST_DIR)/yq-$(YQ_VERSION)
 
 # ====================================================================================
@@ -139,11 +144,17 @@ $(KUSTOMIZE):
 	@rm -fr $(TOOLS_HOST_DIR)/tmp-kustomize
 	@$(OK) installing kustomize $(KUSTOMIZE_VERSION)
 
+# Crossplane BIN download and install
+$(CROSSPLANE_BIN):
+	@$(INFO) installing Crossplane BIN $(CROSSPLANE_BIN_VERSION)
+	@curl -fsSLo $(CROSSPLANE_BIN) --create-dirs https://releases.crossplane.io/$(CROSSPLANE_BIN_CHANNEL)/$(CROSSPLANE_BIN_VERSION)/bin/$(SAFEHOST_PLATFORM)/crossplane?source=build || $(FAIL)
+	@chmod +x $(CROSSPLANE_BIN)
+	@$(OK) installing Crossplane BIN $(CROSSPLANE_BIN_VERSION)
+
 # Crossplane CLI download and install
 $(CROSSPLANE_CLI):
 	@$(INFO) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
-	@curl -fsSLo $(CROSSPLANE_CLI) --create-dirs https://releases.crossplane.io/$(CROSSPLANE_CLI_CHANNEL)/$(CROSSPLANE_CLI_VERSION)/bin/$(SAFEHOST_PLATFORM)/crank?source=build || $(FAIL)
-	@chmod +x $(CROSSPLANE_CLI)
+	@curl -fsSLo $(CROSSPLANE_CLI) --create-dirs https://cli.crossplane.io/$(CROSSPLANE_CLI_CHANNEL)/$(CROSSPLANE_CLI_VERSION)/bin/$(SAFEHOST_PLATFORM)/crossplane?source=build || $(FAIL)
 	@$(OK) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
 
 # helm download and install

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -154,7 +154,8 @@ $(CROSSPLANE_BIN):
 # Crossplane CLI download and install
 $(CROSSPLANE_CLI):
 	@$(INFO) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
-	@curl -fsSLo $(CROSSPLANE_CLI) --create-dirs https://cli.crossplane.io/$(CROSSPLANE_CLI_CHANNEL)/$(CROSSPLANE_CLI_VERSION)/bin/$(SAFEHOST_PLATFORM)/crossplane?source=build || $(FAIL)
+	@curl -sfL "https://cli.crossplane.io/install.sh" | XP_VERSION=$(CROSSPLANE_CLI_VERSION) sh
+	@mv crossplane $(CROSSPLANE_CLI)
 	@chmod +x $(CROSSPLANE_CLI)
 	@$(OK) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
 

--- a/makelib/uptest.mk
+++ b/makelib/uptest.mk
@@ -75,9 +75,9 @@ e2e: build controlplane.down controlplane.up $(UPTEST_LOCAL_DEPLOY_TARGET) uptes
 
 # Renders crossplane compositions in the current project
 #
-# Composition and Function must be defined, Environment and Observeed Resources are optionally available.
+# Composition and Function must be defined, Environment and Observed Resources are optionally available.
 # The command discovers sees by parsing the `render.crossplane.io/*`-annotations of file found in the
-# examples-directorry, usually: `/examples`. This folder can be overwritten: UPTEST_EXAMPLES_FOLDER='other-examples/'
+# examples-directory, usually: `/examples`. This folder can be overwritten: UPTEST_EXAMPLES_FOLDER='other-examples/'
 #
 # Possible values are:
 #  - composition-path (Composition)
@@ -91,6 +91,24 @@ e2e: build controlplane.down controlplane.up $(UPTEST_LOCAL_DEPLOY_TARGET) uptes
 # of files to render.
 #
 #  Example: `make render UPTEST_RENDER_FILES="path/to/example.yaml,another-example.yaml`
+# The render and validate subcommands moved across Crossplane CLI versions:
+#   < v1.17.0             : `beta render`        `beta validate`
+#   >= v1.17.0, <= v2.3.0 : `render`             `beta validate`
+#   > v2.3.0              : `composition render` `resource validate`
+CROSSPLANE_RENDER_MIN_VERSION := v2.3.0
+CROSSPLANE_RENDER_PROMOTED_VERSION := v1.17.0
+ifeq ($(shell printf '%s\n%s\n' "$(CROSSPLANE_CLI_VERSION)" "$(CROSSPLANE_RENDER_MIN_VERSION)" | sort -V | tail -n1),$(CROSSPLANE_RENDER_MIN_VERSION))
+	CROSSPLANE_VALIDATE_CMD := $(CROSSPLANE_CLI) beta validate
+	ifeq ($(shell printf '%s\n%s\n' "$(CROSSPLANE_CLI_VERSION)" "$(CROSSPLANE_RENDER_PROMOTED_VERSION)" | sort -V | tail -n1),$(CROSSPLANE_CLI_VERSION))
+		CROSSPLANE_RENDER_CMD := $(CROSSPLANE_CLI) render
+	else
+		CROSSPLANE_RENDER_CMD := $(CROSSPLANE_CLI) beta render
+	endif
+else
+	CROSSPLANE_RENDER_CMD := $(CROSSPLANE_CLI) composition render
+	CROSSPLANE_VALIDATE_CMD := $(CROSSPLANE_CLI) resource validate
+endif
+
 UPTEST_RENDER_FILES ?=
 UPTEST_EXAMPLES_FOLDER ?= ./examples
 render: $(CROSSPLANE_CLI) ${YQ}
@@ -128,7 +146,7 @@ render: $(CROSSPLANE_CLI) ${YQ}
 			ENVIRONMENT=$${ENVIRONMENT=="null" ? "" : $$ENVIRONMENT}; \
 			OBSERVE=$${OBSERVE=="null" ? "" : $$OBSERVE}; \
 			$(INFO) rendering $$file; \
-			$(CROSSPLANE_CLI) composition render $$file $$COMPOSITION $$FUNCTION $${ENVIRONMENT:+-e $$ENVIRONMENT} $${OBSERVE:+-o $$OBSERVE} -x >> "$(CACHE_DIR)/render/$${OUT_FILE}.yaml"; \
+			$(CROSSPLANE_RENDER_CMD) $$file $$COMPOSITION $$FUNCTION $${ENVIRONMENT:+-e $$ENVIRONMENT} $${OBSERVE:+-o $$OBSERVE} -x >> "$(CACHE_DIR)/render/$${OUT_FILE}.yaml"; \
 			if [ $$? != 0 ]; then \
 				$(ERR) fail rendering $$file; \
 				exit 1; \
@@ -161,7 +179,7 @@ render.show:
 # Validates the rendered output
 #
 # User can supply custom extensions-folder or file with UPTEST_VALIDATE_EXTENSIONS=path/to/extension
-# Additionally there is the ability to restrict which files should be rendered. Samne rules apply as
+# Additionally there is the ability to restrict which files should be rendered. Same rules apply as
 # for `render` and `render.show` command
 #
 # Note: Extension in this context means:
@@ -184,7 +202,7 @@ render.validate:
 			$(WARN) render produced empty output for: $$file; \
 			continue; \
 		fi; \
-		echo "$${RENDERED}" | $(CROSSPLANE_CLI) resource validate $(UPTEST_VALIDATE_EXTENSIONS) - ; \
+		echo "$${RENDERED}" | $(CROSSPLANE_VALIDATE_CMD) $(UPTEST_VALIDATE_EXTENSIONS) - ; \
 		if [ $$? -ne 0 ]; then \
 			$(ERR) fail validating $$file; \
 			exit 1; \

--- a/makelib/uptest.mk
+++ b/makelib/uptest.mk
@@ -128,7 +128,7 @@ render: $(CROSSPLANE_CLI) ${YQ}
 			ENVIRONMENT=$${ENVIRONMENT=="null" ? "" : $$ENVIRONMENT}; \
 			OBSERVE=$${OBSERVE=="null" ? "" : $$OBSERVE}; \
 			$(INFO) rendering $$file; \
-			$(CROSSPLANE_CLI) render $$file $$COMPOSITION $$FUNCTION $${ENVIRONMENT:+-e $$ENVIRONMENT} $${OBSERVE:+-o $$OBSERVE} -x >> "$(CACHE_DIR)/render/$${OUT_FILE}.yaml"; \
+			$(CROSSPLANE_CLI) composition render $$file $$COMPOSITION $$FUNCTION $${ENVIRONMENT:+-e $$ENVIRONMENT} $${OBSERVE:+-o $$OBSERVE} -x >> "$(CACHE_DIR)/render/$${OUT_FILE}.yaml"; \
 			if [ $$? != 0 ]; then \
 				$(ERR) fail rendering $$file; \
 				exit 1; \
@@ -184,7 +184,7 @@ render.validate:
 			$(WARN) render produced empty output for: $$file; \
 			continue; \
 		fi; \
-		echo "$${RENDERED}" | $(CROSSPLANE_CLI) beta validate $(UPTEST_VALIDATE_EXTENSIONS) - ; \
+		echo "$${RENDERED}" | $(CROSSPLANE_CLI) resource validate $(UPTEST_VALIDATE_EXTENSIONS) - ; \
 		if [ $$? -ne 0 ]; then \
 			$(ERR) fail validating $$file; \
 			exit 1; \


### PR DESCRIPTION
- Bump up all tools.
- Use script to download `crossplane-cli`.
- Adjust `render`/`validate` subcommands based on installed CLI version.
- Add `crossplane-bin` as a convenience tool.

