### PR TITLE
fix: propagate GO_TEST_FLAGS to both invocations in `go.test.unit`

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -112,7 +112,7 @@ go.install:
 go.test.unit:
 	@$(INFO) go test unit-tests
 	@mkdir -p $(GO_TEST_OUTPUT)
-	@CGO_ENABLED=$(GO_CGO_ENABLED) $(GOHOST) test -cover $(GO_STATIC_FLAGS) $(GO_PACKAGES) || $(FAIL)
+	@CGO_ENABLED=$(GO_CGO_ENABLED) $(GOHOST) test -cover $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_PACKAGES) || $(FAIL)
 	@CGO_ENABLED=$(GO_CGO_ENABLED) $(GOHOST) test -v -covermode=$(GO_COVER_MODE) -coverprofile=$(GO_TEST_OUTPUT)/coverage.txt $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_PACKAGES) 2>&1 | tee $(GO_TEST_OUTPUT)/unit-tests.log || $(FAIL)
 	@$(OK) go test unit-tests
 


### PR DESCRIPTION
go test is invoked two times in `go.test.unit` target, but only the second invocation has `GO_TEST_FLAGS` propagated. Also pass for the first invocation to align both runs.

This causes test flags like `-timeout` to be ignored for the first run when provided via `GO_TEST_FLAGS` make variable.

Fixes #61